### PR TITLE
mention compatibility for old Julia versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,10 @@ img == img2
 
 ### Paste an image
 ![](docs/src/img/screenshot_paste.gif)
+
+
+### Julia Compatibility
+
+For Julia versions older than v"1.3", you need to manually install the image IO backend [ImageMagcik.jl] first.
+
+[ImageMagick.jl]: https://github.com/JuliaIO/ImageMagick.jl


### PR DESCRIPTION
[skip ci]

For old Julia versions without artifacts, adding ImageMagick as a hard dependency can be a little bit tricky and unstable. Thus in the "best" practice in that time is to avoid the build process as possible as we can, and requesting users to install them manually.

> From https://juliaimages.org/stable/install/#sec_imageio
> > If this is your first time working with images in julia, it's likely that you'll need to install some image IO backends to load the images. 

ImageIO requires at least Julia 1.3.