### PR TITLE
Update CI.yml to deploy docs with tag

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+    tags: '*'
   pull_request:
 jobs:
   test:


### PR DESCRIPTION
There's no documents of `v0.1.0` and `v0.1.1`.
https://hyrodium.github.io/ImageClipboard.jl/stable/

This is because of #24, and this PR fixes this problem.