### PR TITLE
add parameter "-NoProfile" to powershell command

### DIFF
--- a/src/_powershell.jl
+++ b/src/_powershell.jl
@@ -44,7 +44,7 @@ function _powershell(img::AbstractMatrix{<:Colorant})
         getfile = `\$file = get-item\(\"$(path_png)\"\)\;`
         getimg = `\$img = \[System.Drawing.Image\]::Fromfile\(\$file\)\;`
         copyimg = `\[System.Windows.Forms.Clipboard\]::SetImage\(\$img\)\;`
-        cmd = `powershell $addtype $adddrawing $getfile $getimg $copyimg`
+        cmd = `powershell -NoProfile $addtype $adddrawing $getfile $getimg $copyimg`
         run(cmd)
     end
 end


### PR DESCRIPTION
Adds the command line parameter `-NoProfile` to the powershell command to avoid error messages on some systems and faster execution.