### PR TITLE
support WSL (windows subsystem for linux)

### DIFF
--- a/src/ImageClipboard.jl
+++ b/src/ImageClipboard.jl
@@ -27,14 +27,14 @@ function clipboard_img()
         else
             error("Please install wlclipboard or xclip to your system")
         end
+    elseif Sys.iswindows() || Sys.islinux() && haskey(ENV, "WSLENV")
+        img = _powershell()
     elseif Sys.islinux()
         if _isavailable_xclip()
             img = _xclip()
         else
             error("Please install xclip to your system")
         end
-    elseif Sys.iswindows()
-        img = _powershell()
     elseif Sys.isapple()
         img = _osascript()
     else
@@ -57,14 +57,14 @@ function clipboard_img(img::AbstractMatrix{<:Colorant})
         else
             error("Please install wlclipboard or xclip to your system")
         end
+    elseif Sys.iswindows() || Sys.islinux() && haskey(ENV, "WSLENV")
+        _powershell(img)
     elseif Sys.islinux()
         if _isavailable_xclip()
             _xclip(img)
         else
             error("Please install xclip to your system")
         end
-    elseif Sys.iswindows()
-        _powershell(img)
     elseif Sys.isapple()
         _osascript(img)
     else

--- a/src/_powershell.jl
+++ b/src/_powershell.jl
@@ -12,7 +12,7 @@ function _powershell()
         addtype = `Add-Type -AssemblyName System.Windows.Forms\;`
         getimg = `\$img=\[Windows.Forms.Clipboard\]::GetImage\(\)\;`
         saveimg = `if \(\$img -ne \$null\)\{\$img.Save\(\"$(path_png)\"\)\}`
-        cmd = `powershell -NoProfile $addtype $getimg $saveimg`
+        cmd = `powershell.exe -NoProfile $addtype $getimg $saveimg`
         run(cmd)
 
         # Paste from clipboard
@@ -44,7 +44,7 @@ function _powershell(img::AbstractMatrix{<:Colorant})
         getfile = `\$file = get-item\(\"$(path_png)\"\)\;`
         getimg = `\$img = \[System.Drawing.Image\]::Fromfile\(\$file\)\;`
         copyimg = `\[System.Windows.Forms.Clipboard\]::SetImage\(\$img\)\;`
-        cmd = `powershell -NoProfile $addtype $adddrawing $getfile $getimg $copyimg`
+        cmd = `powershell.exe -NoProfile $addtype $adddrawing $getfile $getimg $copyimg`
         run(cmd)
     end
 end

--- a/src/_powershell.jl
+++ b/src/_powershell.jl
@@ -33,18 +33,18 @@ Copy an image to clipboard using `powershell`
 function _powershell(img::AbstractMatrix{<:Colorant})
     mktempdir() do dir
         # Define path
-        path_png = joinpath(dir, "clipboard.png")
+        filename = "clipboard.png"
 
         # Save image
-        save(path_png, img)
+        save(joinpath(dir, filename), img)
 
         # Compose command & run
         addtype = `Add-Type -AssemblyName System.Windows.Forms\;`
         adddrawing = `\[Reflection.Assembly\]::LoadWithPartialName\(\'System.Drawing\'\)\;`
-        getfile = `\$file = get-item\(\"$(path_png)\"\)\;`
+        getfile = `\$file = get-item\(\"$(filename)\"\)\;`
         getimg = `\$img = \[System.Drawing.Image\]::Fromfile\(\$file\)\;`
         copyimg = `\[System.Windows.Forms.Clipboard\]::SetImage\(\$img\)\;`
-        cmd = `powershell.exe -NoProfile $addtype $adddrawing $getfile $getimg $copyimg`
+        cmd = Cmd(`powershell.exe -NoProfile $addtype $adddrawing $getfile $getimg $copyimg`; dir)
         run(cmd)
     end
 end


### PR DESCRIPTION
Currently `clipboard_img()` fails when running under WSL, because xclip doesn't support the windows clipboard for images.

However, the function `_powershell()` can easily handle the clipboard even when called from WSL. The only necessary modification is that the extension `.exe` needs to be explicitly added to the powershell command, which does not break functioning for windows.

Moreover, a check whether running under WSL needs to be added. I chose to check for the environment variable "WSLENV".